### PR TITLE
 HACK: Supress lmkd errors when writing /proc/2306/oom_score_adj

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -1126,10 +1126,6 @@ static ssize_t oom_adj_write(struct file *file, const char __user *buf,
 	}
 
 	task_lock(task);
-	if (!task->mm) {
-		err = -EINVAL;
-		goto err_task_lock;
-	}
 
 	if (!lock_task_sighand(task, &flags)) {
 		err = -ESRCH;


### PR DESCRIPTION
Error: E/[lowmemorykiller] Error writing /proc/5950/oom_score_adj; errno=22

Signed-off-by: Gaganpreet Singh <gaganpannu83@gmail.com>